### PR TITLE
Mock HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ PyRDM depends on:
 
 * [GitPython](https://pypi.python.org/pypi/GitPython/)
 * [requests-oauthlib](https://github.com/requests/requests-oauthlib)
+* [httpretty](https://pypi.python.org/pypi/httpretty/) - for unit testing purposes.
 * pdflatex - to build the user manual.
 * [libspud](https://launchpad.net/spud) - this package is not necessary if you do not wish to run the PyRDM-based publication tool `fluidity-publish` specifically designed for the Fluidity CFD code.
 

--- a/pyrdm/publisher.py
+++ b/pyrdm/publisher.py
@@ -41,6 +41,9 @@ class Publisher:
       if(service == "figshare"):
          self.figshare = Figshare(client_key = self.config.get("figshare", "client_key"), client_secret = self.config.get("figshare", "client_secret"),
                         resource_owner_key = self.config.get("figshare", "resource_owner_key"), resource_owner_secret = self.config.get("figshare", "resource_owner_secret"))
+         # Before doing any creating/uploading on Figshare, try something simple like listing the user's articles
+         # to check that the authentication is successful.
+         self.figshare.test_authentication()
       elif(service == "zenodo"):
          # FIXME: The interface to the Zenodo API is currently not authenticating properly with the Zenodo servers.
          raise NotImplementedError


### PR DESCRIPTION
Use mock HTTP requests in the Figshare module's unit tests. Also add httpretty to the list of dependencies, and remove the dependency on the Publisher module.
