### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Citing
 
 When citing PyRDM, please use the following citation:
 
-* C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014). PyRDM: A Python-based library for automating the management and online publication of scientific software and data. *Journal of Open Research Software*, 2(1):e28, DOI: [http://dx.doi.org/10.5334/jors.bj](http://dx.doi.org/10.5334/jors.bj)
+* C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014). PyRDM: A Python-based library for automating the management and online publication of scientific software and data. *Journal of Open Research Software*, 2(1):e28, DOI: [https://doi.org/10.5334/jors.bj](https://doi.org/10.5334/jors.bj)
 
 Contact
 -------

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -42,7 +42,7 @@ this new data.
 
 The PyRDM library aims to address these needs by facilitating the automated management and publication of software source code and data via online, citable repositories hosted by `Figshare <http://www.figshare.com/>`_, `Zenodo <http://www.zenodo.org/>`_, or a `DSpace <http://www.dspace.org/>`_-based service. The library can be readily incorporated into scientific workflows to allow research outputs to be curated and shared in a straight-forward manner. Further details and technical information are provided in the following paper:
 
-- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014)**. *PyRDM: A Python-based library for automating the management and online publication of scientific software and data*. Journal of Open Research Software, 2(1):e28, DOI: `10.5334/jors.bj <http://dx.doi.org/10.5334/jors.bj>`_
+- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014)**. *PyRDM: A Python-based library for automating the management and online publication of scientific software and data*. Journal of Open Research Software, 2(1):e28, DOI: `10.5334/jors.bj <https://doi.org/10.5334/jors.bj>`_
 
 and in the resources listed `here <http://pyrdm.readthedocs.org/en/latest/references.html>`_.
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -4,9 +4,9 @@ References
 Journal articles
 ----------------
 
-- **C. T. Jacobs, A. Avdis (2016)**. *Git-RDM: A research data management plugin for the Git version control system*. The Journal of Open Source Software, 1(2), DOI: `10.21105/joss.00029 <http://dx.doi.org/10.21105/joss.00029>`_
+- **C. T. Jacobs, A. Avdis (2016)**. *Git-RDM: A research data management plugin for the Git version control system*. The Journal of Open Source Software, 1(2), DOI: `10.21105/joss.00029 <https://doi.org/10.21105/joss.00029>`_
 
-- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014)**. *PyRDM: A Python-based library for automating the management and online publication of scientific software and data*. Journal of Open Research Software, 2(1):e28, DOI: `10.5334/jors.bj <http://dx.doi.org/10.5334/jors.bj>`_
+- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014)**. *PyRDM: A Python-based library for automating the management and online publication of scientific software and data*. Journal of Open Research Software, 2(1):e28, DOI: `10.5334/jors.bj <https://doi.org/10.5334/jors.bj>`_
 
 Conference papers
 -----------------
@@ -18,9 +18,9 @@ Conference papers
 Posters and presentations
 -------------------------
 
-- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2015)**. *PyRDM: A library to facilitate the automated publication of software and data in computational science*. Presented at the `10th International Digital Curation Conference <http://www.dcc.ac.uk/events/idcc15>`_. DOI: `10.6084/m9.figshare.1318710 <http://dx.doi.org/10.6084/m9.figshare.1318710>`_
+- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2015)**. *PyRDM: A library to facilitate the automated publication of software and data in computational science*. Presented at the `10th International Digital Curation Conference <http://www.dcc.ac.uk/events/idcc15>`_. DOI: `10.6084/m9.figshare.1318710 <https://doi.org/10.6084/m9.figshare.1318710>`_
 
-- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014)**. *RDM Green Shoots Project Report: "Research data management: Where software meets data"*. DOI: `10.6084/m9.figshare.1269127 <http://dx.doi.org/10.6084/m9.figshare.1269127>`_
+- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014)**. *RDM Green Shoots Project Report: "Research data management: Where software meets data"*. DOI: `10.6084/m9.figshare.1269127 <https://doi.org/10.6084/m9.figshare.1269127>`_
 
-- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014)**. *Research Data Management for Computational Science*. DOI: `10.6084/m9.figshare.1047219 <http://dx.doi.org/10.6084/m9.figshare.1047219>`_
+- **C. T. Jacobs, A. Avdis, G. J. Gorman, M. D. Piggott (2014)**. *Research Data Management for Computational Science*. DOI: `10.6084/m9.figshare.1047219 <https://doi.org/10.6084/m9.figshare.1047219>`_
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links.

Cheers!